### PR TITLE
Add support for jp109 layout keys

### DIFF
--- a/src/classes/Keyboard.h
+++ b/src/classes/Keyboard.h
@@ -125,7 +125,7 @@ class LedKeyboard {
 			numeric,
 			keys
 		};
-		enum class Key : uint16_t { // 127 items
+		enum class Key : uint16_t { // 132 items
 			
 			logo = static_cast<uint8_t>(KeyAddressGroup::logo) << 8 | 0x01,
 			logo2,
@@ -151,7 +151,7 @@ class LedKeyboard {
 			arrow_right, arrow_left, arrow_bottom, arrow_top, num_lock, num_slash, num_asterisk,
 			num_minus, num_plus, num_enter,
 			num_1, num_2, num_3, num_4, num_5, num_6, num_7, num_8, num_9, num_0,
-			num_dot, intl_backslash, menu,
+			num_dot, intl_backslash, menu, jpbackslash, katakana, yen, henkan, muhenkan,
 			
 			ctrl_left = static_cast<uint8_t>(KeyAddressGroup::keys) << 8 | 0xe0,
 			shift_left, alt_left, win_left,
@@ -248,7 +248,8 @@ class LedKeyboard {
 			Key::n1, Key::n2, Key::n3, Key::n4, Key::n5, Key::n6, Key::n7, Key::n8, Key::n9, Key::n0,
 			Key::enter, Key::backspace, Key::tab, Key::space, Key::minus, Key::equal,
 			Key::open_bracket, Key::close_bracket, Key::backslash, Key::dollar, Key::semicolon, Key::quote, Key::tilde,
-			Key::comma, Key::period, Key::slash, Key::caps_lock, Key::intl_backslash
+			Key::comma, Key::period, Key::slash, Key::caps_lock, Key::intl_backslash,
+                        Key::jpbackslash, Key::katakana, Key::yen, Key::henkan, Key::muhenkan
 		};
 		
 		bool m_isOpen = false;

--- a/src/helpers/utils.cpp
+++ b/src/helpers/utils.cpp
@@ -198,6 +198,11 @@ namespace utils {
 		else if (val == "g7") key = LedKeyboard::Key::g7;
 		else if (val == "g8") key = LedKeyboard::Key::g8;
 		else if (val == "g9") key = LedKeyboard::Key::g9;
+		else if (val == "jpbackslash") key = LedKeyboard::Key::jpbackslash;
+		else if (val == "katakana") key = LedKeyboard::Key::katakana;
+		else if (val == "yen") key = LedKeyboard::Key::yen;
+		else if (val == "henkan") key = LedKeyboard::Key::henkan;
+		else if (val == "muhenkan") key = LedKeyboard::Key::muhenkan;
 		else return false;
 		return true;
 	}


### PR DESCRIPTION
Add support for jp109 layout. This has 5 keys that were not supported.

![g813-jp](https://user-images.githubusercontent.com/3671352/152377732-56632aca-c138-4b3a-a070-846df4ac18c9.jpg)
